### PR TITLE
Subcomments fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1705,4 +1705,14 @@
     [data-night-mode] section.ranking-page > section.ranking table tbody tr.self td.left > section .right time {
         color: #aaa;
     }
+
+    [data-night-mode] section.stream.entry-subcomments section.entry.author > article:before,
+    [data-night-mode] section.stream.entry-subcomments section.entry.link-author > article:before,
+    [data-night-mode] section.stream.entry-subcomments section.entry.own > article:before {
+        left: -2px;
+    }
+
+    [data-night-mode] section.stream.entry-subcomments section.entry.reply:before {
+        background: none;
+    }
 }


### PR DESCRIPTION
Removed blueish line separator between comments
Move author marking lines close to comment

![image](https://user-images.githubusercontent.com/1525842/214956594-8ab7d07d-54e0-4c2a-ad2f-5389a1a9cb65.png)
